### PR TITLE
Setting cap provider default to disabled.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "managed_scaling_minimum_scaling_step_size" {
 
 variable "managed_scaling_status" {
   description = "Whether auto scaling is managed by ECS. Valid values are ENABLED and DISABLED."
-  default     = "ENABLED"
+  default     = "DISABLED"
 }
 
 variable "managed_scaling_target_capacity" {


### PR DESCRIPTION
I am still working out some kinks with the new ECS capacity provider, it's not as plug and play as the docs would have you believe and I haven't had time to sort. For now, we should set the default to DISABLED. Consumers can optionally enable, at their own risk.