### PR TITLE
Need to create capacity provider before destroying.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -22,4 +22,8 @@ resource "aws_ecs_capacity_provider" "primary" {
       target_capacity           = var.managed_scaling_target_capacity
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
There has been an issue with terraforming refreshing the capacity provider due to an error similar to this:

```
error waiting for ECS Capacity Provider (arn:aws:ecs:us-east-1:346024022860:capacity-provider/dev-int-cluster-capacity-provider) to delete: timeout while waiting for state to become 'INACTIVE' (last state: 'ACTIVE', timeout: 20m0s)
```

This issue can be further researched via an open issue with terraform: https://github.com/hashicorp/terraform-provider-aws/issues/14393

This fix isn't confirmed, but worth a shot I say.