### PR TITLE
[nihjur/tf-ecs-cluster] Added full SES access to RoleForECSCluster.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -58,3 +58,9 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_access_policy_attachment" 
   role       = aws_iam_role.ecs_role.name
   policy_arn = aws_iam_policy.cloudwatch_access_policy.arn
 }
+
+# for sending raw emails with the AWS CLI from an EC2 instance
+resource "aws_iam_role_policy_attachment" "ses_full_access_attachment" {
+  role       = aws_iam_role.ecs_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSESFullAccess"
+}


### PR DESCRIPTION
- Added full SES access to RoleForECSCluster.
- - This role needs permission to send (cron job) emails from the AWS CLI in an EC2 instance.