### PR TITLE
Use builtin templatefile function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Terraform state
 .terraform
+.terraform.*
 terraform.tfstate
 terraform.tfstate.backup
 

--- a/ecs_cluster.tftpl
+++ b/ecs_cluster.tftpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo /bin/su -c 'echo ECS_CLUSTER=$${cluster_name} >> /etc/ecs/ecs.config'
+sudo /bin/su -c 'echo ECS_AVAILABLE_LOGGING_DRIVERS="$${logging}" >> /etc/ecs/ecs.config'
+${asg_user_data}


### PR DESCRIPTION
This change was made because of this error when attempting to `terraform init` on this project:
```
Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
```
Terraform docs suggest [replacing this data source](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) with the built in [`templatefile`](https://www.terraform.io/language/functions/templatefile) function if you're on terraform 0.12+. The built in function does the same thing without requiring that provider.

Unfortunately, I don't really know how to test this change. :(