### PR TITLE
refactor: adding a variable to allow custom name tag suffix

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -35,28 +35,28 @@ resource "aws_launch_template" "ecs_container_template" {
 
 locals {
   tags = concat(
-  var.additional_asg_tags,
-  [
-    {
-      key                 = "Name"
-      value               = "${var.ecs_cluster_name} ECS Instance"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Cluster"
-      value               = var.ecs_cluster_name
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Patch Group"
-      value               = local.ecs_patch_group_name
-      propagate_at_launch = true
-    },
-    {
-      key                 = "AmazonECSManaged"
-      value               = "ignored"
-      propagate_at_launch = true
-    }
+    var.additional_asg_tags,
+    [
+      {
+        key                 = "Name"
+        value               = "${var.ecs_cluster_name}${var.ecs_cluster_name_suffix}"
+        propagate_at_launch = true
+      },
+      {
+        key                 = "Cluster"
+        value               = var.ecs_cluster_name
+        propagate_at_launch = true
+      },
+      {
+        key                 = "Patch Group"
+        value               = local.ecs_patch_group_name
+        propagate_at_launch = true
+      },
+      {
+        key                 = "AmazonECSManaged"
+        value               = "ignored"
+        propagate_at_launch = true
+      }
   ])
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,11 @@ variable "ecs_cluster_name" {
   description = "The name of your ECS cluster."
 }
 
+variable "ecs_cluster_name_suffix" {
+  default     = " ECS Instance"
+  description = "The suffix of your ECS cluster, default is ECS instance."
+}
+
 variable "utility_accessible_sg" {
   description = "Pass in the ID of your access security group here."
 }


### PR DESCRIPTION
This MR implements the following
- creates a variable for ecs cluster name suffix
- sets the default value to " ECS Instance" to keep the current format but allow customization of the suffix.
- formatting